### PR TITLE
Fix duplication of sidebar widgets in snb.html

### DIFF
--- a/2.2.1/layouts/Oday_horizon/_page_left.html
+++ b/2.2.1/layouts/Oday_horizon/_page_left.html
@@ -71,7 +71,7 @@
 	list_count="{$oi->site_new_ran_num}" /> 
 <!--@end-->
 	
-<!--@if($oi->site_new_ran_use=='yes')-->
+<!--@if($oi->site_rank_use=='yes')-->
 {@
 	if(!$oi->site_rank_count) $oi->site_rank_count = '10';
 	if(!$oi->site_rank_targets) :

--- a/2.2.1/layouts/Oday_horizon/conf/info.xml
+++ b/2.2.1/layouts/Oday_horizon/conf/info.xml
@@ -922,6 +922,16 @@
 					<title xml:lang="ko">오른쪽</title>
 				</options>	
 			</var>				
+			<var name="use_snb_widgets" type="radio">
+				<title xml:lang="ko">서브 메뉴 하단 위젯</title>
+				<description xml:lang="ko">서브 메뉴 하단에 최신 댓글, 배너 등의 위젯을 표시할지 설정합니다.</description>
+				<options value="yes">
+					<title xml:lang="ko">사용</title>
+				</options>
+				<options value="">
+					<title xml:lang="ko">비사용</title>
+				</options>	
+			</var>
 			<var name="use_snb_force" type="radio">
 				<title xml:lang="ko">서브 메뉴 강제 사용</title>
 				<description xml:lang="ko">서브 페이지에서 사이드 비사용 설정시에도 강제로 서브메뉴를 보이게 설정합니다. 각 게시판에서 사이드 사용 중지한 경우 게시판 설정이 우선합니다. </description>

--- a/2.2.1/layouts/Oday_horizon/snb.html
+++ b/2.2.1/layouts/Oday_horizon/snb.html
@@ -99,6 +99,7 @@
 		</ul>
 	</div>
 	
+<!--@if(!($oi->site_column_c3 == 'yes' && $oi->use_snb_location == 'right'))-->
 {@
 	$oi->site_new_com_num = 10;
 	if(!$oi->site_new_com_srl_use) $oi->site_new_com_srl_use  ='no';
@@ -114,4 +115,5 @@
 	module_srls="{$site_new_com_srl_use}" 
 	list_count="{$oi->site_new_com_num}" />
 	<include target="banner.html"  cond="$oi->banner_sub_use == 'yes'" />
+<!--@end-->
 </div>

--- a/2.2.1/layouts/Oday_horizon/snb.html
+++ b/2.2.1/layouts/Oday_horizon/snb.html
@@ -99,7 +99,7 @@
 		</ul>
 	</div>
 	
-<!--@if(!($oi->site_column_c3 == 'yes' && $oi->use_snb_location == 'right'))-->
+<!--@if($oi->use_snb_widgets == 'yes')-->
 {@
 	$oi->site_new_com_num = 10;
 	if(!$oi->site_new_com_srl_use) $oi->site_new_com_srl_use  ='no';


### PR DESCRIPTION
### 문제
사이트 디자인 설정>레이아웃>서브페이지 설정에서 
<img width="1605" height="752" alt="스크린샷 2025-12-09 150442" src="https://github.com/user-attachments/assets/e85580a2-8b2f-4a09-8863-033258eeb28b" />
이렇게 설정할 경우, snb.html는 하단에 최신 댓글과 배너 위젯을 자동으로 포함하고 있어, 사이드바와 함께 사용할 때 위젯이 중복되거나 의도치 않게 표시되는 문제가 있었습니다.

### 수정
사용자가 명시적으로 서브 메뉴 하단의 위젯 표시 여부를 결정할 수 있도록 use_snb_widgets 설정을 추가했습니다.
<img width="1562" height="878" alt="image" src="https://github.com/user-attachments/assets/f53373e1-5719-4bb0-a678-689fa451aa2d" />
